### PR TITLE
LazyVoters Ping

### DIFF
--- a/src/commands/votum/PingInactiveCommand.ts
+++ b/src/commands/votum/PingInactiveCommand.ts
@@ -16,6 +16,6 @@ export default class PingInactiveCommand extends Command {
       return msg.reply('There is no motion active.')
     }
 
-    return msg.say('These councilors still need to vote:\n\n' + this.council.currentMotion.getRemainingVoters().array().join(' '))
+    return msg.reply('These councilors still need to vote:\n\n' + this.council.currentMotion.getRemainingVoters().array().join(' '))
   }
 }


### PR DESCRIPTION
LazyVoters uses reply instead of say, did this to avoid people ghost-pinging with !lazyvoters.